### PR TITLE
Added support for scatter charts

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,7 +118,9 @@ app.post("/generate", (req, res) => {
     const canvas = createCanvas(1280, 720);
     const chart = echarts.init(canvas);
 
-    chart_data = req.body.option
+    chart_data = req.body.option;
+
+    echarts.registerTransform(ecStat.transform.clustering);
 
     var matches = []
     extractMatches(chart_data, '', matches)

--- a/app.js
+++ b/app.js
@@ -113,6 +113,7 @@ app.post("/generate-svg", (req, res) => {
 app.post("/generate", (req, res) => {
   try {
     const echarts = require('echarts');
+    const ecStat = require('echarts-stat');
     const { createCanvas } = require('canvas');
 
     const canvas = createCanvas(1280, 720);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "canvas": "^2.11.2",
     "cors": "^2.8.5",
     "echarts": "^5.4.3",
+    "echarts-stat": "^1.2.0",
     "express": "^4.18.2",
     "morgan": "^1.10.0",
     "nodemon": "^3.0.1"


### PR DESCRIPTION
The line `echarts.registerTransform(ecStat.transform.clustering)` adds an third-party transform library so that we can have support for Scatter charts.